### PR TITLE
chore: bump haproxy image to haproxy:2.9.11-alpine3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-FROM haproxy:2.9.7-alpine3.19
+FROM haproxy:2.9.11-alpine3.20
 
 USER root
 


### PR DESCRIPTION
Bump haproxy base image to latest before release.