### PR TITLE
Add option to autostart managed containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN set -ex; \
         bind-tools \
         nano \
         vim \
-        envsubst; \
+        envsubst \
+        jq; \
     chmod -R 777 /tmp
 
 COPY --chmod=775 *.sh /

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ You should set `BIND_ADDRESS` to the IP on which server with ExApps can accept r
 
 `TIMEOUT_SERVER`: timeout for ExApp to start responding to NC request, default: **1800s**
 
+`NC_AUTOSTART_CONTAINERS`: if set, automatically start managed app containers (useful for Podman users)
+
 `NC_HAPROXY_PASSWORD_FILE`: Specifies path to a file containing the password for HAProxy. 
 
 > [!NOTE]


### PR DESCRIPTION
This is useful for Podman, where containers are not autostarted on boot like they are under the Docker daemon. The usual way to solve this problem under Podman is to use systemd, but it's annoying to create a systemd unit for every ExApps-managed container by hand.

I tested this exact `start.sh` in production, with and without the environment variable set.